### PR TITLE
Drop word "block" in closure type names

### DIFF
--- a/Examples/ObjectFormExample/ObjectFormExample/FruitForm/FruitFormData.swift
+++ b/Examples/ObjectFormExample/ObjectFormExample/FruitForm/FruitFormData.swift
@@ -42,7 +42,7 @@ class FruitFormData: NSObject, FormDataSource {
                                    updateTag: "name",
                                    value: fruit.name ?? "",
                                    placeholder: nil,
-                                   validation: {
+                                   validator: {
                                     return !(fruit.name?.isEmpty ?? true)
 
         }))
@@ -51,15 +51,13 @@ class FruitFormData: NSObject, FormDataSource {
                                    icon: "",
                                    updateTag: "price",
                                    value: fruit.price,
-                                   placeholder: "",
-                                   validation: nil))
+                                   placeholder: ""))
 
         basicRows.append(DoubleRow(title: "Weight",
                                    icon: "",
                                    updateTag: "weight",
                                    value: fruit.weight,
-                                   placeholder: "",
-                                   validation: nil))
+                                   placeholder: ""))
 
         basicRows.append(TextViewRow(title: "Note",
                                      updateTag: "note",

--- a/Sources/ObjectForm/FormDataSource.swift
+++ b/Sources/ObjectForm/FormDataSource.swift
@@ -57,7 +57,7 @@ extension FormDataSource {
             for rowIndex in 0..<numberOfRows(at: section) {
                 let currentRow = row(at: IndexPath(row: rowIndex, section: section))
 
-                if let validation = currentRow.validation, validation() == false {
+                if let validator = currentRow.validator, validator() == false {
                     isValid = false
                     currentRow.validationFailed = true
                 }

--- a/Sources/ObjectForm/FormRow.swift
+++ b/Sources/ObjectForm/FormRow.swift
@@ -14,13 +14,13 @@ protocol Taggable: AnyObject {
 }
 
 public class BaseRow : NSObject, Taggable {
-    public typealias validationBlock = (() -> Bool)
+    public typealias Validator = (() -> Bool)
 
     var title: String?
     var icon: String?
     var updateTag: String?
     var placeholder: String?
-    var validation: validationBlock?
+    var validator: Validator?
     var validationFailed: Bool?
 
     public var baseCell: FormInputCell {
@@ -61,7 +61,7 @@ public class TypedRow<T>: BaseRow where T: CustomStringConvertible, T: Equatable
         return T.self == t
     }
 
-    public required init(title: String, icon: String, updateTag: String, value: T?, placeholder: String? = nil, validation: validationBlock? = nil) {
+    public required init(title: String, icon: String, updateTag: String, value: T?, placeholder: String? = nil, validator: Validator? = nil) {
         self.cell = TypedInputCell()
         super.init()
         self.title = title
@@ -69,7 +69,7 @@ public class TypedRow<T>: BaseRow where T: CustomStringConvertible, T: Equatable
         self.value = value
         self.updateTag = updateTag
         self.placeholder = placeholder
-        self.validation = validation
+        self.validator = validator
     }
 }
 

--- a/Sources/ObjectForm/FormRow.swift
+++ b/Sources/ObjectForm/FormRow.swift
@@ -78,7 +78,7 @@ public typealias SelectRowConvertible = CustomStringConvertible & SelectCellOutp
 /// Model for a row that selects a value from a list of values
 public class SelectRow<T>: BaseRow where T: SelectRowConvertible {
 
-    public typealias ValueChangedBlock = ((T?) -> Void)
+    public typealias ValueChangedHandler = ((T?) -> Void)
 
     public override var baseValue: CustomStringConvertible? {
         get { return value }
@@ -91,7 +91,7 @@ public class SelectRow<T>: BaseRow where T: SelectRowConvertible {
     var value: T?
     public var cell: SelectInputCell<T>
 
-    private var valueChangeBlock: ValueChangedBlock?
+    private var valueChangedHandler: ValueChangedHandler?
     
     public override var description: String {
         return value?.description ?? ""
@@ -108,16 +108,16 @@ public class SelectRow<T>: BaseRow where T: SelectRowConvertible {
         updateTag: String,
         value: T?,
         listOfValues: [T],
-        valueChangeBlock: ValueChangedBlock? = nil
+        valueChangedHandler: ValueChangedHandler? = nil
     ) {
-        self.cell = SelectInputCell(listOfValues: listOfValues, valueChangeBlock: valueChangeBlock)
+        self.cell = SelectInputCell(listOfValues: listOfValues, valueChangedHandler: valueChangedHandler)
         super.init()
         self.title = title
         self.icon = icon
         self.value = value
         self.updateTag = updateTag
         self.placeholder = placeholder
-        self.valueChangeBlock = valueChangeBlock
+        self.valueChangedHandler = valueChangedHandler
     }
 }
 

--- a/Sources/ObjectForm/view/CollectionPicker.swift
+++ b/Sources/ObjectForm/view/CollectionPicker.swift
@@ -9,10 +9,10 @@
 import Foundation
 import UIKit
 
-public typealias PickerCompletionBlock = (_ selectedIndex: Int) -> Void
+public typealias PickerCompletionHandler = (_ selectedIndex: Int) -> Void
 
 protocol CollectionPicker {
-    init(collection: [Any], completionCallback:@escaping PickerCompletionBlock)
+    init(collection: [Any], completionHandler: @escaping PickerCompletionHandler)
 }
 
 public class TableCollectionPicker: UIViewController, CollectionPicker {
@@ -32,11 +32,11 @@ public class TableCollectionPicker: UIViewController, CollectionPicker {
         return view
     }()
 
-    private var completionCallback: PickerCompletionBlock?
+    private var completionHandler: PickerCompletionHandler?
     private var collection: [Any]
 
-    public required init(collection: [Any], completionCallback: @escaping PickerCompletionBlock) {
-        self.completionCallback = completionCallback
+    public required init(collection: [Any], completionHandler: @escaping PickerCompletionHandler) {
+        self.completionHandler = completionHandler
         self.collection = collection
         super.init(nibName: nil, bundle: nil)
         title = "设置"
@@ -75,7 +75,7 @@ extension TableCollectionPicker: UITableViewDataSource, UITableViewDelegate {
     }
 
     public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        completionCallback?(indexPath.row)
+        completionHandler?(indexPath.row)
         navigationController?.popViewController(animated: true)
     }
 }

--- a/Sources/ObjectForm/view/SelectInputCell.swift
+++ b/Sources/ObjectForm/view/SelectInputCell.swift
@@ -34,7 +34,7 @@ public class SelectInputCell<T: SelectRowConvertible>: FormInputCell {
         self.init(style: .default, reuseIdentifier: "InputCellIdentifier")
         self.listOfValues = listOfValues
 
-        self.collectionPicker = TableCollectionPicker(collection: listOfValues, completionCallback: { [weak self] pickedIndex in
+        self.collectionPicker = TableCollectionPicker(collection: listOfValues, completionHandler: { [weak self] pickedIndex in
             guard let self = self else { return }
             self.textField.text = String(describing: listOfValues[pickedIndex])
             self.delegate?.cellDidChangeValue(self, value: listOfValues[pickedIndex].outputValue)

--- a/Sources/ObjectForm/view/SelectInputCell.swift
+++ b/Sources/ObjectForm/view/SelectInputCell.swift
@@ -22,15 +22,15 @@ extension String: SelectCellOutputible {
 
 public class SelectInputCell<T: SelectRowConvertible>: FormInputCell {
     
-    typealias ValueChangedBlock = ((T) -> Void)
+    typealias ValueChangedHandler = ((T) -> Void)
 
     private var collectionPicker: TableCollectionPicker?
 
     private var listOfValues: [T]?
 
-    private var valueChangeBlock: SelectRow<T>.ValueChangedBlock?
+    private var valueChangedHandler: SelectRow<T>.ValueChangedHandler?
 
-    convenience init(listOfValues: [T], valueChangeBlock: SelectRow<T>.ValueChangedBlock?) {
+    convenience init(listOfValues: [T], valueChangedHandler: SelectRow<T>.ValueChangedHandler?) {
         self.init(style: .default, reuseIdentifier: "InputCellIdentifier")
         self.listOfValues = listOfValues
 
@@ -39,7 +39,7 @@ public class SelectInputCell<T: SelectRowConvertible>: FormInputCell {
             self.textField.text = String(describing: listOfValues[pickedIndex])
             self.delegate?.cellDidChangeValue(self, value: listOfValues[pickedIndex].outputValue)
 
-            valueChangeBlock?(listOfValues[pickedIndex])
+            valueChangedHandler?(listOfValues[pickedIndex])
         })
 
         textField.isUserInteractionEnabled = false


### PR DESCRIPTION
New names fit more well in Swift & Cocoa conventions.