### PR TITLE
Rename BaseRow property: updateTag to kvcKey

### DIFF
--- a/Examples/ObjectFormExample/ObjectFormExample/FruitForm/FruitFormData.swift
+++ b/Examples/ObjectFormExample/ObjectFormExample/FruitForm/FruitFormData.swift
@@ -39,7 +39,7 @@ class FruitFormData: NSObject, FormDataSource {
 
         basicRows.append(StringRow(title: "Name",
                                    icon: "",
-                                   updateTag: "name",
+                                   kvcKey: "name",
                                    value: fruit.name ?? "",
                                    placeholder: nil,
                                    validator: {
@@ -49,23 +49,23 @@ class FruitFormData: NSObject, FormDataSource {
 
         basicRows.append(DoubleRow(title: "Price",
                                    icon: "",
-                                   updateTag: "price",
+                                   kvcKey: "price",
                                    value: fruit.price,
                                    placeholder: ""))
 
         basicRows.append(DoubleRow(title: "Weight",
                                    icon: "",
-                                   updateTag: "weight",
+                                   kvcKey: "weight",
                                    value: fruit.weight,
                                    placeholder: ""))
 
         basicRows.append(TextViewRow(title: "Note",
-                                     updateTag: "note",
+                                     kvcKey: "note",
                                      value: fruit.note ?? "-"))
 
         basicRows.append(SelectRow(title: "Retailer",
                                    icon: "",
-                                   updateTag: "retailer",
+                                   kvcKey: "retailer",
                                    value: fruit.retailer,
                                      listOfValues: ["Walmart", "McDonald", "Carrefour"]))
     }

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ ObjectForm doesn't fight with you to write UIKit code. By design, it is simple t
 This project has no dependency of any other library.
 
 ## Features
+
 - Bind class model to form rows
 - Automatic keyboards types according to model types
 - Form rows are type safe
@@ -77,7 +78,7 @@ class FruitFormData: NSObject, FormDataSource {
 
       basicRows.append(StringRow(title: "Name",
                                  icon: "",
-                                 updateTag: "name",
+                                 kvcKey: "name",
                                  value: fruit.name ?? "",
                                  placeholder: nil,
                                  validation: nil))
@@ -85,14 +86,14 @@ class FruitFormData: NSObject, FormDataSource {
       // Row are type safe
       basicRows.append(DoubleRow(title: "Price",
                                  icon: "",
-                                 updateTag: "price",
+                                 kvcKey: "price",
                                  value: fruit.price,
                                  placeholder: "",
                                  validation: nil))
 
       // You can build as many rows as you want
       basicRows.append(TextViewRow(title: "Note",
-                                   updateTag: "note",
+                                   kvcKey: "note",
                                    value: fruit.note ?? "-"))
 
   }
@@ -146,7 +147,7 @@ By providing a validation block when building a row, you can provide any validai
 ```swift
 basicRows.append(StringRow(title: "Name",
                            icon: "",
-                           updateTag: "name",
+                           kvcKey: "name",
                            value: fruit.name ?? "",
                            placeholder: nil,
                            validation: {
@@ -212,13 +213,13 @@ class TextViewRow: BaseRow {
         return "<TextViewRow> \(title ?? "")"
     }
 
-    required init(title: String, updateTag: String, value: String?) {
+    required init(title: String, kvcKey: String, value: String?) {
         self.cell = TextViewInputCell()
 
         super.init()
 
         self.title = title
-        self.updateTag = updateTag
+        self.kvcKey = kvcKey
         self.value = value
         self.placeholder = nil
     }

--- a/Sources/ObjectForm/FormDataSource.swift
+++ b/Sources/ObjectForm/FormDataSource.swift
@@ -31,7 +31,7 @@ extension FormDataSource {
     /// TODO: refactor updateItem and save as protocol method with default implementations
     public func updateItem(at indexPath: IndexPath, value: Any?) -> Bool {
         let currentRow = row(at: indexPath)
-        guard let keyPath = currentRow.updateTag else {
+        guard let keyPath = currentRow.kvcKey else {
             assertionFailure("Row keyPath should not be empty")
             return false
         }

--- a/Sources/ObjectForm/FormRow.swift
+++ b/Sources/ObjectForm/FormRow.swift
@@ -10,7 +10,7 @@ import Foundation
 import UIKit
 
 protocol Taggable: AnyObject {
-    var updateTag: String? { get set }
+    var kvcKey: String? { get set }
 }
 
 public class BaseRow : NSObject, Taggable {
@@ -18,7 +18,10 @@ public class BaseRow : NSObject, Taggable {
 
     var title: String?
     var icon: String?
-    var updateTag: String?
+
+    // Update object properties using the key with key-value-coding
+    var kvcKey: String?
+
     var placeholder: String?
     var validator: Validator?
     var validationFailed: Bool?
@@ -61,13 +64,13 @@ public class TypedRow<T>: BaseRow where T: CustomStringConvertible, T: Equatable
         return T.self == t
     }
 
-    public required init(title: String, icon: String, updateTag: String, value: T?, placeholder: String? = nil, validator: Validator? = nil) {
+    public required init(title: String, icon: String, kvcKey: String, value: T?, placeholder: String? = nil, validator: Validator? = nil) {
         self.cell = TypedInputCell()
         super.init()
         self.title = title
         self.icon = icon
         self.value = value
-        self.updateTag = updateTag
+        self.kvcKey = kvcKey
         self.placeholder = placeholder
         self.validator = validator
     }
@@ -105,7 +108,7 @@ public class SelectRow<T>: BaseRow where T: SelectRowConvertible {
     public required init(
         title: String,
         icon: String,
-        updateTag: String,
+        kvcKey: String,
         value: T?,
         listOfValues: [T],
         valueChangedHandler: ValueChangedHandler? = nil
@@ -115,7 +118,7 @@ public class SelectRow<T>: BaseRow where T: SelectRowConvertible {
         self.title = title
         self.icon = icon
         self.value = value
-        self.updateTag = updateTag
+        self.kvcKey = kvcKey
         self.placeholder = placeholder
         self.valueChangedHandler = valueChangedHandler
     }
@@ -149,7 +152,7 @@ class ButtonRow: BaseRow {
         super.init()
         self.title = title
         self.icon = icon
-        self.updateTag = nil
+        self.kvcKey = nil
         self.placeholder = nil
     }
 }
@@ -178,13 +181,13 @@ public class TextViewRow: BaseRow {
         return String.self == t
     }
 
-    public required init(title: String, updateTag: String, value: String?) {
+    public required init(title: String, kvcKey: String, value: String?) {
         self.cell = TextViewInputCell()
 
         super.init()
 
         self.title = title
-        self.updateTag = updateTag
+        self.kvcKey = kvcKey
         self.value = value
         self.placeholder = nil
     }


### PR DESCRIPTION
`updateTag` is not a good name. Rename it to kvcKey so that key value coding is more discoverable.