### PR TITLE
Mark Row and Cell classes as open so that they can be subclassed

### DIFF
--- a/Sources/ObjectForm/row/ButtonRow.swift
+++ b/Sources/ObjectForm/row/ButtonRow.swift
@@ -9,7 +9,7 @@ import Foundation
 import UIKit
 
 /// Model for a row that is a button
-open ButtonRow: BaseRow {
+open class ButtonRow: BaseRow {
 
     public override var baseValue: CustomStringConvertible? {
         get { return nil }

--- a/Sources/ObjectForm/row/ButtonRow.swift
+++ b/Sources/ObjectForm/row/ButtonRow.swift
@@ -24,11 +24,11 @@ open class ButtonRow: BaseRow {
 
     let actionTag: String
 
-    override var description: String {
+  open override var description: String {
         return "<ButtonRow> \(title ?? "")"
     }
 
-    required init(title: String, icon: String, actionTag: String) {
+  required public init(title: String, icon: String, actionTag: String) {
         self.actionTag = actionTag
 
         self.cell = ButtonCell()

--- a/Sources/ObjectForm/row/ButtonRow.swift
+++ b/Sources/ObjectForm/row/ButtonRow.swift
@@ -1,6 +1,6 @@
 //
 //  File.swift
-//  
+//
 //
 //  Created by Jake on 3/2/20.
 //
@@ -9,7 +9,7 @@ import Foundation
 import UIKit
 
 /// Model for a row that is a button
-class ButtonRow: BaseRow {
+open ButtonRow: BaseRow {
 
     public override var baseValue: CustomStringConvertible? {
         get { return nil }

--- a/Sources/ObjectForm/row/FormRow.swift
+++ b/Sources/ObjectForm/row/FormRow.swift
@@ -13,7 +13,7 @@ protocol Taggable: AnyObject {
     var kvcKey: String? { get set }
 }
 
-public class BaseRow : NSObject, Taggable {
+open class BaseRow : NSObject, Taggable {
     public typealias Validator = (() -> Bool)
 
     var title: String?

--- a/Sources/ObjectForm/row/SelectRow.swift
+++ b/Sources/ObjectForm/row/SelectRow.swift
@@ -11,7 +11,7 @@ import UIKit
 public typealias SelectRowConvertible = CustomStringConvertible & SelectCellOutputible & Equatable
 
 /// Model for a row that selects a value from a list of values
-public class SelectRow<T>: BaseRow where T: SelectRowConvertible {
+open class SelectRow<T>: BaseRow where T: SelectRowConvertible {
 
     public typealias ValueChangedHandler = ((T?) -> Void)
 

--- a/Sources/ObjectForm/row/TextViewRow.swift
+++ b/Sources/ObjectForm/row/TextViewRow.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public class TextViewRow: BaseRow {
+open class TextViewRow: BaseRow {
 
     public override var baseCell: FormInputCell {
         return cell

--- a/Sources/ObjectForm/row/TypedRow.swift
+++ b/Sources/ObjectForm/row/TypedRow.swift
@@ -14,7 +14,7 @@ public typealias DoubleRow = TypedRow<Double>
 public typealias DateRow = TypedRow<Date>
 
 // A generic model for inputing a value
-public class TypedRow<T>: BaseRow where T: CustomStringConvertible, T: Equatable {
+open class TypedRow<T>: BaseRow where T: CustomStringConvertible, T: Equatable {
     public override var baseValue: CustomStringConvertible? {
         get { return value }
         set { value = newValue as? T }

--- a/Sources/ObjectForm/view/FormInputCell.swift
+++ b/Sources/ObjectForm/view/FormInputCell.swift
@@ -48,7 +48,7 @@ open class FormInputCell: UITableViewCell {
         hStack.pinMargins(to: contentView, edges: [.leading, .trailing])
     }
 
-    required init(coder aDecoder: NSCoder) {
+  required public init(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 

--- a/Sources/ObjectForm/view/FormInputCell.swift
+++ b/Sources/ObjectForm/view/FormInputCell.swift
@@ -15,7 +15,7 @@ public protocol FormCellDelegate: AnyObject {
 }
 
 // A base class for all input cell, simply defining some sytles
-public class FormInputCell: UITableViewCell {
+open class FormInputCell: UITableViewCell {
 
     public static let identifier = "FormInputCell"
 

--- a/Sources/ObjectForm/view/SelectInputCell.swift
+++ b/Sources/ObjectForm/view/SelectInputCell.swift
@@ -53,7 +53,7 @@ open class SelectInputCell<T: SelectRowConvertible>: FormInputCell {
         accessoryType = .disclosureIndicator
     }
 
-    required init(coder aDecoder: NSCoder) {
+  required public init(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 

--- a/Sources/ObjectForm/view/SelectInputCell.swift
+++ b/Sources/ObjectForm/view/SelectInputCell.swift
@@ -20,8 +20,8 @@ extension String: SelectCellOutputible {
     }
 }
 
-public class SelectInputCell<T: SelectRowConvertible>: FormInputCell {
-    
+open class SelectInputCell<T: SelectRowConvertible>: FormInputCell {
+
     typealias ValueChangedHandler = ((T) -> Void)
 
     private var collectionPicker: TableCollectionPicker?

--- a/Sources/ObjectForm/view/TextViewInputCell.swift
+++ b/Sources/ObjectForm/view/TextViewInputCell.swift
@@ -24,7 +24,7 @@ open class TextViewInputCell: FormInputCell {
         textViewVC.delegate = self
     }
 
-    required init(coder aDecoder: NSCoder) {
+  required public init(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 

--- a/Sources/ObjectForm/view/TextViewInputCell.swift
+++ b/Sources/ObjectForm/view/TextViewInputCell.swift
@@ -9,7 +9,7 @@
 import Foundation
 import UIKit
 
-public class TextViewInputCell: FormInputCell {
+open class TextViewInputCell: FormInputCell {
 
     private let textViewVC = TextViewVC()
 

--- a/Sources/ObjectForm/view/TypedInputCell.swift
+++ b/Sources/ObjectForm/view/TypedInputCell.swift
@@ -9,7 +9,7 @@
 import Foundation
 import UIKit
 
-public class TypedInputCell<T>: FormInputCell, UITextFieldDelegate {
+open class TypedInputCell<T>: FormInputCell, UITextFieldDelegate {
 
     private var dateFormatter: DateFormatter = {
         let dateFormatter = DateFormatter()

--- a/Sources/ObjectForm/view/TypedInputCell.swift
+++ b/Sources/ObjectForm/view/TypedInputCell.swift
@@ -31,7 +31,7 @@ open class TypedInputCell<T>: FormInputCell, UITextFieldDelegate {
         textField.delegate = self
     }
 
-    required init(coder aDecoder: NSCoder) {
+  required public init(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 


### PR DESCRIPTION
The classes in question were marked as `public`, which is not
a problematic when the package is imported directly into a project.

When the package is installed using a package manager (SPM or other)
these classes couldn't be subclassed because of the `public` access
level. Marking them as `open` solves this problem.

Fixes #13 